### PR TITLE
Fixed: github link

### DIFF
--- a/app/src/main/java/com/example/aclass/ui/AboutActivity.java
+++ b/app/src/main/java/com/example/aclass/ui/AboutActivity.java
@@ -45,7 +45,7 @@ public class AboutActivity extends AppCompatActivity {
                 .setDescription("本软件仅供哈工大本科生进行课表相关操作使用，项目已开源。如果你在使用的过程中发现任何bug，或对本软件的发展有建议，请联系yuxiang.wei.cs@gmail.com。感谢您的支持。")
                 .setImage(R.drawable.bg_black)
                 .addItem(help)
-                .addGitHub("https://github.com/Yuxiang-Wei/HITSchedule")
+                .addGitHub("Yuxiang-Wei/HITSchedule")
                 .addEmail("Yuxiang.Wei.CS@gmail.com")
                 .addGroup("Thanks for")
                 .addItem(timetableView)


### PR DESCRIPTION
第一次使用这个软件，感觉很赞。谢谢您开发这么方便的软件！:+1:

刚发现指向 GitHub 的链接前面多了一个 `https://github.com/`：
<img src="https://user-images.githubusercontent.com/24741764/46084312-f789d400-c1d5-11e8-8aa9-adcccdf420c6.jpg" height=200px>

看了下 Android About Page 的 README，`addGitHub` 是不需要加 `https://github.com/` 前缀的哈：
<img src="https://user-images.githubusercontent.com/24741764/46084461-4cc5e580-c1d6-11e8-89a4-81dc9626b091.png" height=300px>
